### PR TITLE
Remove unneeded apostrophe

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ provider for PHP.  Inspired by [js-hyperclick](https://github.com/AsaAyers/js-hy
 Hyperclick package is required.
 
 ### Usage
-`<cmd-click>` on a supported word to jump it's declaration or location.
+`<cmd-click>` on a supported word to jump its declaration or location.
 
 ### Features
 * **Variables**: jump to their last definition in current file.


### PR DESCRIPTION
A possessive belonging to an "it" doesn't need an apostrophe. Don't believe me? Ask [the Oatmeal](http://theoatmeal.com/comics/apostrophe) (look for the velociraptor)!